### PR TITLE
Fixes for QP-8218 and APIGW-34

### DIFF
--- a/Releasenotes.txt
+++ b/Releasenotes.txt
@@ -1,3 +1,7 @@
+1.4.7.0
+Features
+    APIGW-34 : Added missing routes needed for Qmatic Webbboking: branchgroups_api and sms_api
+
 1.4.6.0
 Bug fixes
     QP-8218 : Mobile ticket slow response : Introduced settings for timeouts to Orchestra back-end and documented how to set undertow worker threads.

--- a/Releasenotes.txt
+++ b/Releasenotes.txt
@@ -1,3 +1,7 @@
+1.4.6.0
+Bug fixes
+    QP-8218 : Mobile ticket slow response : Introduced settings for timeouts to Orchestra back-end and documented how to set undertow worker threads.
+
 1.4.5.0
 Features
     Updated JRE shipped with API GW to JRE from Zulu java. jre 1.8.0_192.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-currentVersion=1.4.5.0
+currentVersion=1.4.6.0
 artifactory_username=github
 
 qpCommonGeo=qp-common-geo

--- a/src/main/java/com/qmatic/apigw/rest/CentralRestClient.java
+++ b/src/main/java/com/qmatic/apigw/rest/CentralRestClient.java
@@ -53,8 +53,13 @@ public final class CentralRestClient {
                 .setConnectTimeout(getConnectTimeout())
                 .setReadTimeout(getReadTimeout())
                 .build();
+<<<<<<< Updated upstream
         log.info("connectTimeout: {}", connectTimeout);
         log.info("readTimeout: {}", readTimeout);
+=======
+        log.debug("connectTimeout: {}", connectTimeout);
+        log.debug("readTimeout: {}", readTimeout);
+>>>>>>> Stashed changes
     }
 
     private int getConnectTimeout() {

--- a/src/main/java/com/qmatic/apigw/rest/CentralRestClient.java
+++ b/src/main/java/com/qmatic/apigw/rest/CentralRestClient.java
@@ -1,22 +1,29 @@
 package com.qmatic.apigw.rest;
 
 import com.qmatic.apigw.GatewayConstants;
+import com.qmatic.apigw.exception.CentralCommunicationException;
 import com.qmatic.apigw.filters.FilterConstants;
 import com.qmatic.apigw.properties.OrchestraProperties;
 import com.qmatic.common.geo.Branch;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import javax.annotation.PostConstruct;
+import java.io.IOException;
 import java.nio.charset.Charset;
+
+import static org.springframework.http.HttpStatus.GATEWAY_TIMEOUT;
 
 @Component
 public final class CentralRestClient {
@@ -30,14 +37,41 @@ public final class CentralRestClient {
     private String mobileServiceBranchesUrl;
     @Value("${currentStatus.visits_on_branch_url}")
     private String visitsOnBranchUrl;
-    private CentralHttpErrorHandler centralErrorHandler;
+    @Value("${orchestra.central.connectTimeout:0}")
+    String connectTimeout;
+    @Value("${orchestra.central.readTimeout:0}")
+    String readTimeout;
+    @Autowired
+    private RestTemplateBuilder restTemplateBuilder;
     private RestTemplate restTemplate;
 
     @PostConstruct
     protected void init() {
-        centralErrorHandler = new CentralHttpErrorHandler();
-        restTemplate = new RestTemplate();
-        restTemplate.setErrorHandler(centralErrorHandler);
+        CentralHttpErrorHandler centralErrorHandler = new CentralHttpErrorHandler();
+        restTemplate = restTemplateBuilder
+                .errorHandler(centralErrorHandler)
+                .setConnectTimeout(getConnectTimeout())
+                .setReadTimeout(getReadTimeout())
+                .build();
+        log.info("connectTimeout: {}", connectTimeout);
+        log.info("readTimeout: {}", readTimeout);
+    }
+
+    private int getConnectTimeout() {
+        return parseInteger(connectTimeout, "orchestra.central.connectTimeout");
+    }
+
+    private int parseInteger(String value, String attribute) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException nfe) {
+            log.error("Unable to use value {} from setting {}, it is not a valid integer. Defaulting to 0.", value, attribute);
+        }
+        return 0;
+    }
+
+    private int getReadTimeout() {
+        return parseInteger(readTimeout, "orchestra.central.readTimeout");
     }
 
     /**
@@ -50,7 +84,15 @@ public final class CentralRestClient {
                 new HttpEntity<>(createAuthorizationHeader(userCredentials)), Branch[].class, new Object[]{});
             return allBranches.getBody();
         } catch(RuntimeException e) {
-            log.warn("", e);
+            throw logAndConvertException(e);
+        }
+    }
+
+    private RuntimeException logAndConvertException(RuntimeException e) {
+        log.warn("", e);
+        if (e instanceof ResourceAccessException && e.getCause() instanceof IOException) {
+            return new CentralCommunicationException("1000", e.getMessage(), GATEWAY_TIMEOUT.value(), "");
+        } else {
             throw e;
         }
     }
@@ -71,8 +113,7 @@ public final class CentralRestClient {
             }
             return new Branch[] {};
         } catch(RuntimeException e) {
-            log.warn("", e);
-            throw e;
+            throw logAndConvertException(e);
         }
     }
 
@@ -101,8 +142,7 @@ public final class CentralRestClient {
             }
             return new VisitStatusMap();
         } catch(RuntimeException e) {
-            log.warn("", e);
-            throw e;
+            throw logAndConvertException(e);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,11 @@ endpoints:
 server:
   # define server port for gateway
   port: 9090
+# By default undertow uses 8*<no of available CPUs> as the no of worker threads
+# If the API-GW has many long-running requests this might need to be increased to ensure there are idle workers for new requests.
+# Uncomment the two sections below to set the no of workers
+#  undertow:
+#   worker-threads: 128
 #  ssl:
 #    key-store: classpath:keystore.jks
 #    key-store-password: secret
@@ -37,6 +42,12 @@ orchestra:
   # define URL for orchestra central installation
   central:
     url: http://localhost:8080
+# By default the communication to the backend server has no timeout
+# Uncomment and adjust the values below to set timeout values.
+# NOTE: This only applies to requests starting with /geo and also to requests defined in the checksumRoutes below (normally /MobileTicket/MyVisit... routes)
+# NOTE2: The value is specified in milliseconds
+    connectTimeout: 10000
+    readTimeout: 10000
 
   # SSL trust store for the jvm
   # trustStore: conf/truststore.jks

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,8 +46,13 @@ orchestra:
 # Uncomment and adjust the values below to set timeout values.
 # NOTE: This only applies to requests starting with /geo and also to requests defined in the checksumRoutes below (normally /MobileTicket/MyVisit... routes)
 # NOTE2: The value is specified in milliseconds
+<<<<<<< Updated upstream
     connectTimeout: 10000
     readTimeout: 10000
+=======
+#    connectTimeout: 10000
+#    readTimeout: 10000
+>>>>>>> Stashed changes
 
   # SSL trust store for the jvm
   # trustStore: conf/truststore.jks

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -129,6 +129,12 @@ zuul:
     appointment_api:
        path: /rest/appointment/**
        url: ${orchestra.central.url}/qsystem/rest/appointment
+    branchgroups_api:
+       path: /rest/config/branchGroups/**
+       url: ${orchestra.central.url}/qsystem/rest/config/branchGroups
+    sms_api:
+       path: /rest/notification/**
+       url: ${orchestra.central.url}/notification/
     entrypoint_api:
         path: /rest/entrypoint/**
         url: ${orchestra.central.url}/qsystem/rest/entrypoint


### PR DESCRIPTION
QP-8218 : Added possibility to set timeouts for requests using restTemplate towards central system. Also added comments sections in application.yml on how to configure worker threads for undertow.
APIGW-34: Added some default routes needed in application.yml needed for qmatic webbooking